### PR TITLE
updated TweetEntitiesMention in models

### DIFF
--- a/pytwitter/models/tweet.py
+++ b/pytwitter/models/tweet.py
@@ -66,8 +66,10 @@ class TweetEntitiesCashtag(TweetEntitiesHashtag):
 
 
 @dataclass
-class TweetEntitiesMention(TweetEntitiesHashtag):
-    ...
+class TweetEntitiesMention(BaseModel):
+    start: Optional[int] = field(default=None, repr=False)
+    end: Optional[int] = field(default=None, repr=False)
+    username: Optional[str] = field(default=None)
 
 
 @dataclass


### PR DESCRIPTION
Stream API returns mention text as 'username', not 'tag', as in hashtags, so the data model for mentions needs to be updated in order to gather mention data correctly.