### PR TITLE
feat(media): :sparkles: update api for media upload v2

### DIFF
--- a/pytwitter/api.py
+++ b/pytwitter/api.py
@@ -855,7 +855,6 @@ class Api:
         """
 
         args = {
-            "command": "INIT",
             "total_bytes": total_bytes,
             "media_type": media_type,
         }
@@ -867,9 +866,9 @@ class Api:
             )
 
         resp = self._request(
-            url=f"{self.BASE_URL_V2}/media/upload",
+            url=f"{self.BASE_URL_V2}/media/upload/initialize",
             verb="POST",
-            data=args,
+            json=args,
         )
         data = self._parse_response(resp=resp)
         if return_json:
@@ -893,13 +892,9 @@ class Api:
         :return: True if upload success.
         """
         resp = self._request(
-            url=f"{self.BASE_URL_V2}/media/upload",
+            url=f"{self.BASE_URL_V2}/media/upload/{media_id}/append",
             verb="POST",
-            params={
-                "command": "APPEND",
-                "media_id": media_id,
-            },
-            data={"segment_index": segment_index},
+            json={"segment_index": segment_index},
             files={"media": media},
         )
         if resp.ok:
@@ -921,12 +916,8 @@ class Api:
         :return: Media upload response.
         """
         resp = self._request(
-            url=f"{self.BASE_URL_V2}/media/upload",
+            url=f"{self.BASE_URL_V2}/media/upload/{media_id}/finalize",
             verb="POST",
-            params={
-                "command": "FINALIZE",
-                "media_id": media_id,
-            },
         )
         data = self._parse_response(resp=resp)
         if return_json:

--- a/tests/apis/test_media_upload_v2.py
+++ b/tests/apis/test_media_upload_v2.py
@@ -40,7 +40,7 @@ def test_media_upload_simple_v2(api_with_user, helpers):
 def test_upload_media_chunked_init_v2(api_with_user, helpers):
     responses.add(
         responses.POST,
-        url="https://api.twitter.com/2/media/upload",
+        url="https://api.twitter.com/2/media/upload/initialize",
         json=helpers.load_json_data(
             "testdata/apis/media_upload_v2/upload_chunk_init_resp.json"
         ),
@@ -68,7 +68,7 @@ def test_upload_media_chunked_append_v2(api_with_user, helpers):
 
     responses.add(
         responses.POST,
-        url="https://api.twitter.com/2/media/upload",
+        url=f"https://api.twitter.com/2/media/upload/{media_id}/append",
     )
 
     with open("testdata/apis/media_upload/x-logo.png", "rb") as media:
@@ -88,7 +88,7 @@ def test_upload_media_chunked_append_v2(api_with_user, helpers):
 
     responses.add(
         responses.POST,
-        url="https://api.twitter.com/2/media/upload",
+        url=f"https://api.twitter.com/2/media/upload/{media_id}/append",
         status=401,
         json={"errors": [{"code": 32, "message": "Could not authenticate you."}]},
     )
@@ -106,7 +106,7 @@ def test_upload_media_chunked_finalize_v2(api_with_user, helpers):
 
     responses.add(
         responses.POST,
-        url="https://api.twitter.com/2/media/upload",
+        url=f"https://api.twitter.com/2/media/upload/{media_id}/finalize",
         json=helpers.load_json_data(
             "testdata/apis/media_upload_v2/upload_chunk_finalize_resp.json"
         ),


### PR DESCRIPTION
Refer: https://devcommunity.x.com/t/media-upload-endpoints-update-and-extended-migration-deadline/241818